### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const browsersync = require('browser-sync').create();
 //sass.compiler = require('dart-sass');
 
 // Sass Task
-function scssTask() {
+async function scssTask() {
   return src('app/scss/style.scss', { sourcemaps: true })
     .pipe(sass())
     .pipe(postcss([autoprefixer(), cssnano()]))


### PR DESCRIPTION
Add the word async before function scssTask to solve a problem found to run gulp this month (july/2024). Here is the error: 
https://drive.google.com/file/d/1sM59zAmMNjhdWgd1k8bBq8tgok6dGSpi/view?usp=sharing

the function now is:
// Sass Task
// adding async before the function
async function scssTask() {
  return src("app/scss/style.scss", { sourcemaps: true })
    .pipe(sass())
    .pipe(postcss([autoprefixer(), cssnano()]))
    .pipe(dest("dist", { sourcemaps: "." }));
}